### PR TITLE
prune old refs during fetch

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func cmdRun(cmd *exec.Cmd) error {
 }
 
 func gitFetch(repoPath string, repo *git.Repository, remote string) error {
-	cmd := exec.Command("git", "fetch", remote, "--tags")
+	cmd := exec.Command("git", "fetch", "-p", remote, "--tags")
 	cmd.Dir = repoPath
 	return cmdRun(cmd)
 }


### PR DESCRIPTION
We had a problem:

1. earlier we had a `test` branch on a remote
2. it's already deleted
3. new `test/xxxx` branch is created
4. git is conflicted:

```
failed syncing /github.com/storj/storj: execution: exit status 1:
error: cannot lock ref 'refs/remotes/github/test/xxxx': 'refs/remotes/github/test' exists; cannot create 'refs/remotes/github/test/xxxx'
From [github.com:storj/storj](http://github.com:storj/storj)
! [new branch]          test/xxxx -> github/test/xxxx  (unable to update local ref)
    main.cmdRun:59
    main.gitFetch:65
    main.(*Repo).FetchAll:181
    main.(*Repo).FetchAndSync:250
    main.(*Handler).ServeHTTP:327
    net/http.serverHandler.ServeHTTP:2887
    net/http.(*conn).serve:1952
    ```